### PR TITLE
Removing [] from --tags and --skip-tags

### DIFF
--- a/docs/docsite/rst/playbook_guide/playbooks_tags.rst
+++ b/docs/docsite/rst/playbook_guide/playbooks_tags.rst
@@ -334,8 +334,8 @@ Once you have added tags to your tasks, includes, blocks, plays, roles, and impo
 :ref:`ansible-playbook` offers five tag-related command-line options:
 
 * ``--tags all`` - run all tasks, ignore tags (default behavior)
-* ``--tags [tag1, tag2]`` - run only tasks with either the tag ``tag1`` or the tag ``tag2``
-* ``--skip-tags [tag3, tag4]`` - run all tasks except those with either the tag ``tag3`` or the tag ``tag4``
+* ``--tags tag1, tag2`` - run only tasks with either the tag ``tag1`` or the tag ``tag2``
+* ``--skip-tags tag3, tag4`` - run all tasks except those with either the tag ``tag3`` or the tag ``tag4``
 * ``--tags tagged`` - run only tasks with at least one tag
 * ``--tags untagged`` - run only tasks with no tags
 


### PR DESCRIPTION
As it defined in the issue #397 at https://github.com/ansible/ansible-documentation/issues/397, the brackets must be removed